### PR TITLE
Fixing a GoogleVoice API issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "ipaddress"
 gem "linkedin" # LinkedIn Command
 gem "json"
 gem "rest-client"
-gem "googlevoiceapi" # Google Voice Command
+#gem "googlevoiceapi" # Google Voice Command
 gem "twilio-ruby" # Twilio Command
 gem "command_line_reporter"
 gem "mechanize"
@@ -27,4 +27,3 @@ gem "geocoder"
 gem "slack-notifier"
 gem "xmpp4r"
 gem "acme-client"
-

--- a/lib/cartero/commands/sms/googlevoice.rb
+++ b/lib/cartero/commands/sms/googlevoice.rb
@@ -47,6 +47,8 @@ class GoogleVoice < ::Cartero::Command
   end
 
   def setup
+    Puts "[!] - Temporareily disabled until a new ruby gem is found. googlevoiceapi no longer exists."
+    exit(1)
     require 'erb'
     require 'googlevoiceapi'
 


### PR DESCRIPTION
Temporarily disabling for new installations. It is no longer supported.
We need to find a new gem and/or implement it ourselves.