### PR TITLE
Adding Support for Bash for Windows & Changing Commands description definition

### DIFF
--- a/data/scripts/setup.sh
+++ b/data/scripts/setup.sh
@@ -167,6 +167,13 @@ function install_ruby_nix
   fi
 }
 
+function install_ruby_bash_win
+{
+  print_status "Installing Linux dependencies"
+  sudo apt-get -y install ruby ruby-dev ruby2.0 ruby2.0-dev build-essential zlib1g-dev libxslt-dev libxml2-dev zlib1g zlib1g-dev libxml2 libxml2-dev libxslt-dev locate libreadline6-dev libcurl4-openssl-dev git-core libssl-dev libyaml-dev openssl autoconf libtool ncurses-dev bison curl wget xsel libapr1 libaprutil1 libsvn1 libpcap-dev
+  print_status "Installing the bundler Gem"
+  gem install bundler >> $LOGFILE 2>&1
+}
 function install_mongodb {
 	case $(uname -a) in
 		*Darwin*)
@@ -190,7 +197,12 @@ function install_mongodb {
 			sudo pacman -Syu mongodb
 			;;
 		*)
-			print_status "OS not supported. Install mongodb manually"
+      if [[ $(cat /proc/version) =~ Microsoft ]]; then
+        print_status "Installing mongodb on Bash for Windows"
+      	sudo apt-get -y install mongodb
+      else
+        print_status "OS not supported. Install mongodb manually"
+      fi
 			;;
 	esac
 }
@@ -242,7 +254,12 @@ else
     gem install bundler >> $LOGFILE 2>&1
     ;;
   *)
-    print_status "OS not supported. Install ruby manually"
+    if [[ $(cat /proc/version) =~ Microsoft ]]; then
+      print_status "Installing ruby on Bash for Windows"
+      install_ruby_bash_win
+    else
+      print_status "OS not supported. Install ruby dependencies manually"
+    fi
     ;;
   esac
 fi

--- a/lib/cartero/base.rb
+++ b/lib/cartero/base.rb
@@ -118,6 +118,7 @@ module Cartero
         load t
       end
     end
+
     def self.load_payloads
       Dir[File.dirname(__FILE__) + "/payloads/**/*.rb"].each do |t|
         load t
@@ -125,6 +126,44 @@ module Cartero
 
       Dir[ENV["HOME"] + "/.cartero/payloads/**/*.rb"].each do |t|
         load t
+      end
+    end
+
+    def self.initialize_commands
+      # Initialize all avilable loaded Commands that are parto of
+      # ::Cartero::Commands and are its supper class is << ::::Cartero::Command.
+      ::Cartero::Commands.constants.each do |klass|
+        if RUBY_VERSION =~ /1.9.3/
+          # get the constant from Object Concatenation on ruby 1.9.3
+          # Kernel.const_get does not work using strings as a value.
+          const = ::Object.const_get("Cartero").const_get("Commands").const_get(klass)
+        else
+          # Get the constant from the Kernel using the symbol
+          const = Kernel.const_get("Cartero::Commands::#{klass}")
+        end
+        # Check if the plugin has a super class and if the type is Plugin
+        if const.respond_to?(:superclass) && const.superclass == ::Cartero::Command
+          ::Cartero::COMMANDS[klass.to_s] = const
+        end
+      end
+    end
+
+    def self.initialize_payloads
+      # Initialize all avilable loaded Commands that are parto of
+      # ::Cartero::Commands and are its supper class is << ::Cartero::Command.
+      ::Cartero::Payloads.constants.each do |klass|
+        if RUBY_VERSION =~ /1.9.3/
+          # get the constant from Object Concatenation on ruby 1.9.3
+          # Kernel.const_get does not work using strings as a value.
+          const = ::Object.const_get("Cartero").const_get("Payloads").const_get(klass)
+        else
+          # Get the constant from the Kernel using the symbol
+          const = Kernel.const_get("Cartero::Payloads::#{klass}")
+        end
+        # Check if the plugin has a super class and if the type is Plugin
+        if const.respond_to?(:superclass) && const.superclass == ::Cartero::Payload
+          ::Cartero::PAYLOADS[klass.to_s] = const
+        end
       end
     end
   end

--- a/lib/cartero/cli.rb
+++ b/lib/cartero/cli.rb
@@ -15,9 +15,8 @@ module Cartero
       @options.commands = []
       @options.payloads = []
 
-      initialize_commands
-
-      initialize_payloads
+      Cartero::Base.initialize_commands
+      Cartero::Base.initialize_payloads
 
       # Setup Correct Crypto Box ( AES || RBNACL )
       ::Cartero::CryptoBox.setup
@@ -191,46 +190,6 @@ module Cartero
         rescue StandardError => e
           $stderr.puts e.to_s
           $stderr.puts e.backtrace if @options.debug
-        end
-      end
-    end
-
-    private
-
-    def initialize_commands
-      # Initialize all avilable loaded Commands that are parto of
-      # ::Cartero::Commands and are its supper class is << ::::Cartero::Command.
-      ::Cartero::Commands.constants.each do |klass|
-        if RUBY_VERSION =~ /1.9.3/
-          # get the constant from Object Concatenation on ruby 1.9.3
-          # Kernel.const_get does not work using strings as a value.
-          const = ::Object.const_get("Cartero").const_get("Commands").const_get(klass)
-        else
-          # Get the constant from the Kernel using the symbol
-          const = Kernel.const_get("Cartero::Commands::#{klass}")
-        end
-        # Check if the plugin has a super class and if the type is Plugin
-        if const.respond_to?(:superclass) && const.superclass == ::Cartero::Command
-          ::Cartero::COMMANDS[klass.to_s] = const
-        end
-      end
-    end
-
-    def initialize_payloads
-      # Initialize all avilable loaded Commands that are parto of
-      # ::Cartero::Commands and are its supper class is << ::Cartero::Command.
-      ::Cartero::Payloads.constants.each do |klass|
-        if RUBY_VERSION =~ /1.9.3/
-          # get the constant from Object Concatenation on ruby 1.9.3
-          # Kernel.const_get does not work using strings as a value.
-          const = ::Object.const_get("Cartero").const_get("Payloads").const_get(klass)
-        else
-          # Get the constant from the Kernel using the symbol
-          const = Kernel.const_get("Cartero::Payloads::#{klass}")
-        end
-        # Check if the plugin has a super class and if the type is Plugin
-        if const.respond_to?(:superclass) && const.superclass == ::Cartero::Payload
-          ::Cartero::PAYLOADS[klass.to_s] = const
         end
       end
     end

--- a/lib/cartero/commands/admin/admin_console.rb
+++ b/lib/cartero/commands/admin/admin_console.rb
@@ -6,14 +6,18 @@ module Commands
 # Documentation for AdminConsole < ::Cartero::Command
 class AdminConsole < ::Cartero::Command
   include CommandLineReporter
+
+  description(
+    name: "Administration Console",
+    description: "Cartero Console based Admnistration Interface. It allows users to interact with the captured data (i.e. hits, persons, credentials.)",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Admin",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+  
   def initialize
-    super(name: "Administration Console",
-          description: "Cartero Console based Admnistration Interface. It allows users to interact with the captured data (i.e. hits, persons, credentials.)",
-          author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-          type: "Admin",
-          license: "LGPL",
-          references: ["https://section9labs.github.io/Cartero"]
-          ) do |opts|
+    super do |opts|
       opts.on("-p", "--persons [LATEST_N]", Integer,
         "Display the list of persons that responded") do |n|
         @options.persons = n || 50

--- a/lib/cartero/commands/admin/admin_web.rb
+++ b/lib/cartero/commands/admin/admin_web.rb
@@ -4,14 +4,18 @@ module Cartero
 module Commands
 # Documentation for AdminWeb < ::Cartero::Command
 class AdminWeb < ::Cartero::Command
+
+  description(
+    name: "Cartero Administration Web Application",
+    description: "Cartero WebApp based Admnistration Interface. It allows users to interact with the captured data (i.e. hits, persons, credentials.) using a friendly Web Application.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Admin",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+  
   def initialize
-    super(name: "Cartero Administration Web Application",
-      description: "Cartero WebApp based Admnistration Interface. It allows users to interact with the captured data (i.e. hits, persons, credentials.) using a friendly Web Application.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Admin",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.on("-i", "--ip 1.1.1.1", String,
         "Sets IP interface, default is 0.0.0.0") do |ip|
         @options.ip = ip

--- a/lib/cartero/commands/admin/beef_console.rb
+++ b/lib/cartero/commands/admin/beef_console.rb
@@ -6,17 +6,20 @@ module Commands
 # Documentation for AdminConsole < ::Cartero::Command
 class BeefConsole < ::Cartero::Command
   include CommandLineReporter
+
+  description(
+    name: " Beef Administration Console",
+    description: "Cartero Console based Admnistration Interface for Beef API. It allows users to interact with the captured data (i.e. hooks, logs, modules, commands, dns, etc.)",
+    author: ['Matias P. Brutti <matias [©] section9labs.com>'],
+    type: "Admin",
+    license: "LGPL",
+    references: [
+                'https://section9labs.github.io/Cartero',
+                'http://beefproject.com'
+                ]
+  )
   def initialize
-    super(name: " Beef Administration Console",
-          description: "Cartero Console based Admnistration Interface for Beef API. It allows users to interact with the captured data (i.e. hooks, logs, modules, commands, dns, etc.)",
-          author: ['Matias P. Brutti <matias [©] section9labs.com>'],
-          type: "Admin",
-          license: "LGPL",
-          references: [
-                      'https://section9labs.github.io/Cartero',
-                      'http://beefproject.com'
-                      ]
-          ) do |opts|
+    super do |opts|
       opts.separator ""
       opts.separator "Beef Commands:"
 

--- a/lib/cartero/commands/admin/m_s_f_rpcd.rb
+++ b/lib/cartero/commands/admin/m_s_f_rpcd.rb
@@ -3,14 +3,18 @@ module Cartero
 module Commands
 # Documentation for MSFRpcd < ::Cartero::Commands
 class MSFRpcd < ::Cartero::Command
-   def initialize
-    super(name: "Metasploit MSFRPCd Interface",
-      description: "This command is a simple control for metasploit's RPC protocol. ",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Admin",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+
+  description(
+    name: "Metasploit MSFRPCd Interface",
+    description: "This command is a simple control for metasploit's RPC protocol. ",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Admin",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+  
+  def initialize
+    super do |opts|
 
       opts.on("-S", "--start", "Starts background RPC Server.") do
         @options.command = "start_rpc"

--- a/lib/cartero/commands/admin/update.rb
+++ b/lib/cartero/commands/admin/update.rb
@@ -3,14 +3,16 @@ module Cartero
 module Commands
 # Documentation for Update < ::Cartero::Command
 class Update < ::Cartero::Command
+  description(
+    name: "Cartero Git Update Command",
+    description: "The command provides an automated way of keeping the tool updated with the official or another personal repository.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Admin",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
   def initialize
-    super(name: "Cartero Git Update Command",
-      description: "The command provides an automated way of keeping the tool updated with the official or another personal repository.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Admin",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.on("--update", "Update All") do
         @options.update = true
       end

--- a/lib/cartero/commands/cloner.rb
+++ b/lib/cartero/commands/cloner.rb
@@ -4,19 +4,23 @@ module Cartero
 module Commands
 # Documentation for Cloner < ::Cartero::Command
 class Cloner < ::Cartero::Command
+
+  description(
+    name: "Web Application Cloner",
+    description: "This command allows a user to clone a site using Cartero's webservers." +
+                 "Additionally, it will automatically edit forms, catch traffic, block bots, and redirect" +
+                 "to the original site, among many other things.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Infrastructure",
+    license: "LGPL",
+    references: [
+      "https://section9labs.github.io/Cartero",
+      "https://section9labs.github.io/Cartero"
+      ]
+  )
+
   def initialize
-    super(name: "Web Application Cloner",
-          description: "This command allows a user to clone a site using Cartero's webservers." +
-                       "Additionally, it will automatically edit forms, catch traffic, block bots, and redirect" +
-                       "to the original site, among many other things.",
-          author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-          type: "Infrastructure",
-          license: "LGPL",
-          references: [
-            "https://section9labs.github.io/Cartero",
-            "https://section9labs.github.io/Cartero"
-            ]
-          ) do |opts|
+    super do |opts|
       opts.on("-U", "--url URL_PATH", String,
         "Full Path of site to clone") do |url|
         @options.url = url
@@ -59,6 +63,7 @@ class Cloner < ::Cartero::Command
       end
     end
   end
+
   attr_accessor :url
   attr_accessor :url_route
   attr_accessor :path

--- a/lib/cartero/commands/database.rb
+++ b/lib/cartero/commands/database.rb
@@ -3,14 +3,18 @@ module Cartero
 module Commands
 # Documentation for ::Cartero::Command
 class Mongo < ::Cartero::Command
-   def initialize
-    super(name: "MongoDB Launcher",
-      description: "Command Responsible for starting and stopping the underlaying MongoDB database used to store data.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Admin",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+
+  description(
+    name: "MongoDB Launcher",
+    description: "Command Responsible for starting and stopping the underlaying MongoDB database used to store data.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Admin",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+
+  def initialize
+    super do |opts|
       opts.on("-s","--start",
         "Start MongoDB") do
         @options.action = "start"

--- a/lib/cartero/commands/infrastructure/d_n_s_server.rb
+++ b/lib/cartero/commands/infrastructure/d_n_s_server.rb
@@ -1,21 +1,22 @@
 module Cartero
 module Commands
 class DNSServer < ::Cartero::Command
-	def initialize
-		super(
-          name: "Malicious DNS Server",
-					description: "Using the power of RubyDNS we counstracted a malicious" +
-                       " DNS server that allows your to arbitrarely redirect specific " +
-                       "domains and upstream others to a non-malicious DNS for normal resolution.",
-					author: ["Matias Brutti <matias [©] section9labs.com>"],
-          type:"Infrastructure",
-          license: "LGPL",
-          references: [
-            "https://section9labs.github.io/Cartero",
-            "https://github.com/ioquatix/rubydns"
-            ]
 
-    ) do |opts|
+	description(
+		name: "Malicious DNS Server",
+		description: "Using the power of RubyDNS we counstracted a malicious" +
+								 " DNS server that allows your to arbitrarely redirect specific " +
+								 "domains and upstream others to a non-malicious DNS for normal resolution.",
+		author: ["Matias Brutti <matias [©] section9labs.com>"],
+		type:"Infrastructure",
+		license: "LGPL",
+		references: [
+			"https://section9labs.github.io/Cartero",
+			"https://github.com/ioquatix/rubydns"
+			]
+	)
+	def initialize
+		super do |opts|
 			opts.on("-I", "--ip [IP_ADDRESS]", String,
     		"IP address of domain to hook") do |ip|
       	@options.ip = ip

--- a/lib/cartero/commands/infrastructure/lets_encrypt.rb
+++ b/lib/cartero/commands/infrastructure/lets_encrypt.rb
@@ -1,19 +1,20 @@
 module Cartero
 module Commands
 class LetsEncrypt < ::Cartero::Command
-    def initialize
-        super(
-          name: "Lets Encrypt",
-          description: "LetsEncrypt Command capable of generating a key and a cert for one of more domains.",
-          author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-          type:"Infrastructure",
-          license: "LGPL",
-          references: [
-            "https://section9labs.github.io/Cartero",
-            "https://github.com/unixcharles/acme-client"
-            ]
 
-    ) do |opts|
+  description(
+    name: "Lets Encrypt",
+    description: "LetsEncrypt Command capable of generating a key and a cert for one of more domains.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type:"Infrastructure",
+    license: "LGPL",
+    references: [
+      "https://section9labs.github.io/Cartero",
+      "https://github.com/unixcharles/acme-client"
+      ]
+  )
+  def initialize
+    super do |opts|
       opts.on("-W", "--webserver WEBSERVER_FOLDER", String,
         "Sets the sinatra WebServer full path for payload creation") do |path|
         @options.path = path

--- a/lib/cartero/commands/listener.rb
+++ b/lib/cartero/commands/listener.rb
@@ -1,18 +1,22 @@
 #encoding: utf-8
-# encoding: UTF-8
 # Documentation goes here.
 module Cartero
 module Commands
 # Documentation for Listener < ::Cartero::Command
 class Listener < ::Cartero::Command
+
+  description(
+    name: "Cartero Customizeable Web Server",
+    description: "Listener is the command that serves our customized WebServers " +
+                 "hosting pages on one or more ports at any given time.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Infrastructure",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+
   def initialize
-    super(name: "Cartero Customizeable Web Server",
-      description: "Listener is the command that serves our customized WebServers hosting pages on one or more ports at any given time.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Infrastructure",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.on("-i", "--ip 1.1.1.1", String,
         "Sets IP interface, default is 0.0.0.0") do |ip|
         @options.ip = ip
@@ -83,7 +87,7 @@ class Listener < ::Cartero::Command
     end
 
     @puma = Puma::CarteroCLI.new([])
-    @puma.options[:environment] = 'production'
+		@puma.options[:environment] = 'production'
     @puma.options[:min_threads] = 4
     @puma.options[:max_threads] = 16
     @puma.options[:quiet] = true

--- a/lib/cartero/commands/mail/carta.rb
+++ b/lib/cartero/commands/mail/carta.rb
@@ -3,14 +3,18 @@ module Cartero
 module Commands
 # Documentation for Mailer < ::Cartero::Commands
 class Mailer < Command
+
+  description(
+    name: "Customized Mass Email Command",
+    description: "Mailer is responsible for crafting and sending emails from a simple txt based email all the way to complicated email templates that can individualize each email as if it was being written by a person.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Delivery",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+  
   def initialize
-    super(name: "Customized Mass Email Command",
-      description: "Mailer is responsible for crafting and sending emails from a simple txt based email all the way to complicated email templates that can individualize each email as if it was being written by a person.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Delivery",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.on("-D", "--data DATA_FILE", String,
         "File containing template data sets") do |data|
         @options.data = data
@@ -197,7 +201,7 @@ class Mailer < Command
 		entity[:subject] ||= subject
     entity[:from] ||= from
     entity[:payload] = ::Cartero::CryptoBox.encrypt(entity.to_json)
- 
+
     # Add Text body if was provided.
     unless body.nil?
       mail[:body] = ERB.new(body).result(entity.get_binding)

--- a/lib/cartero/commands/mail/webmailer.rb
+++ b/lib/cartero/commands/mail/webmailer.rb
@@ -3,14 +3,18 @@ module Cartero
 module Commands
 # Documentation for WebMailer < ::Cartero::Command
 class WebMailer < ::Cartero::Command
+
+  description(
+    name: "Web Form Email Command",
+    description: "As the name states, it abuses(uses) open or vulnerable email forms available on the internet. This command is very useful when bypassing email filters during a penetration test. Since most webforms might be whitelisted.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Delivery",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+  
   def initialize
-    super(name: "Web Form Email Command",
-      description: "As the name states, it abuses(uses) open or vulnerable email forms available on the internet. This command is very useful when bypassing email filters during a penetration test. Since most webforms might be whitelisted.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Delivery",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.on("-R", "--raw RAW_REQUEST_FILE", String,
         "Sets WebMail Raw Request") do |rawfile|
         @options.raw = rawfile

--- a/lib/cartero/commands/servers.rb
+++ b/lib/cartero/commands/servers.rb
@@ -7,14 +7,18 @@ module Cartero
 module Commands
 # Documentatation for ::Cartero::Command
 class Servers < ::Cartero::Command
+
+  description(
+    name: "Server Template Manager",
+    description: "Servers keeps email servers templates. It allows uses to easily craft servers configuration files for emails servers, Linkedin, Twilio, Google Voice, WebMailer, etc.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Infrastructure",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+  
   def initialize
-    super(name: "Server Template Manager",
-      description: "Servers keeps email servers templates. It allows uses to easily craft servers configuration files for emails servers, Linkedin, Twilio, Google Voice, WebMailer, etc.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Infrastructure",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.on("-a","--add NAME", String,
         "Add Server") do |name|
         @options.name = name
@@ -128,7 +132,7 @@ class Servers < ::Cartero::Command
    when /twilio/
      "#{File.dirname(__FILE__)}/../../../templates/server/twilio.json"
 	when /jabber/
-	   "#{File.dirname(__FILE__)}/../../../templates/server/jabber.json"	
+	   "#{File.dirname(__FILE__)}/../../../templates/server/jabber.json"
 	 else
       "#{File.dirname(__FILE__)}/../../../templates/server/server.json"
     end

--- a/lib/cartero/commands/sms/googlevoice.rb
+++ b/lib/cartero/commands/sms/googlevoice.rb
@@ -3,17 +3,21 @@ module Cartero
 module Commands
 # Documentation for GoogleVoice < ::Cartero::Command
 class GoogleVoice < ::Cartero::Command
+
+  description(
+    name: "Google Voice SMS/MMS Text Messages Command",
+    description: "Using Google Voice as a delivery method, an attacker can send multiple individually crafted text messages.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Delivery",
+    license: "LGPL",
+    references: [
+      "https://section9labs.github.io/Cartero",
+      "http://voice.google.com"
+      ]
+  )
+  
   def initialize
-    super(name: "Google Voice SMS/MMS Text Messages Command",
-      description: "Using Google Voice as a delivery method, an attacker can send multiple individually crafted text messages.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Delivery",
-      license: "LGPL",
-      references: [
-        "https://section9labs.github.io/Cartero",
-        "http://voice.google.com"
-        ]
-      ) do |opts|
+    super do |opts|
       opts.on("-D", "--data DATA_FILE", String,
         "File containing template data sets") do |data|
         @options.data = data

--- a/lib/cartero/commands/sms/imessage.rb
+++ b/lib/cartero/commands/sms/imessage.rb
@@ -3,14 +3,18 @@ module Cartero
 module Commands
 # Documentation for IMessage < ::Cartero::Command
 class IMessage < ::Cartero::Command
+
+  description(
+    name: "Apple Messages Command",
+    description: "The commands wraps AppleScripts to send customized messages to emails or phone numbers using Messages infrastructure.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Delivery",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+   
   def initialize
-    super(name: "Apple Messages Command",
-      description: "The commands wraps AppleScripts to send customized messages to emails or phone numbers using Messages infrastructure.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Delivery",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.separator "IMPORTANT: This command only works on OSX"
       opts.separator ""
 

--- a/lib/cartero/commands/sms/twilio.rb
+++ b/lib/cartero/commands/sms/twilio.rb
@@ -3,14 +3,18 @@ module Cartero
 module Commands
 # Documentatin for Twilio < ::Cartero::Command
 class Twilio < ::Cartero::Command
+
+  description(
+    name: "Twilio SMS/MMS Mass Messenger",
+    description: "Using Twilio as a delivery method, an attacker can send multiple individually crafted text messages. This method requires to have an active (paid) account with Twilio.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Delivery",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+  
   def initialize
-    super(name: "Twilio SMS/MMS Mass Messenger",
-      description: "Using Twilio as a delivery method, an attacker can send multiple individually crafted text messages. This method requires to have an active (paid) account with Twilio.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Delivery",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.on("-D", "--data DATA_FILE", String,
         "File containing template data sets") do |data|
         @options.data = data

--- a/lib/cartero/commands/social/linkedin.rb
+++ b/lib/cartero/commands/social/linkedin.rb
@@ -6,14 +6,18 @@ module Commands
 # Documentation for LinkedIn < ::Cartero::Command
 class LinkedIn < ::Cartero::Command
   include CommandLineReporter
+
+  description(
+    name: "LinkedIn Automation Mass Sender",
+    description: "Using LinkedIn Network an attacker is able to use one or more accounts on an automated way to deliver messages, updates && group updates contaning simple messages, malicious payloads, etc.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Social Delivery",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+  
   def initialize
-    super(name: "LinkedIn Automation Mass Sender",
-      description: "Using LinkedIn Network an attacker is able to use one or more accounts on an automated way to deliver messages, updates && group updates contaning simple messages, malicious payloads, etc.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Social Delivery",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.on("-D", "--data DATA_FILE", String,
         "File containing template data sets") do |data|
         @options.data = data

--- a/lib/cartero/commands/social/xmpp.rb
+++ b/lib/cartero/commands/social/xmpp.rb
@@ -1,20 +1,21 @@
-#encoding: utf-8 
+#encoding: utf-8
 module Cartero
 module Commands
 class Xmpp < ::Cartero::Command
-	def initialize
-		super(
-          name: "Mass XMPP Messenger",
-          description: "A simple XMPP Client capable of sending templated messages to multiple users.",
-          author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-          type:"Social",
-          license: "LGPL",
-          references: [
-            "https://section9labs.github.io/Cartero",
-            "https://github.com/xmpp4r/xmpp4r"
-            ]
 
-    ) do |opts|
+	description(
+		name: "Mass XMPP Messenger",
+		description: "A simple XMPP Client capable of sending templated messages to multiple users.",
+		author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+		type:"Social",
+		license: "LGPL",
+		references: [
+			"https://section9labs.github.io/Cartero",
+			"https://github.com/xmpp4r/xmpp4r"
+			]
+	)
+	def initialize
+		super do |opts|
 			opts.on("-D", "--data DATA_FILE", String,
         "File containing template data sets") do |data|
         @options.data = data

--- a/lib/cartero/commands/templates.rb
+++ b/lib/cartero/commands/templates.rb
@@ -5,16 +5,20 @@ module Cartero
 module Commands
 # Documentation for Templates < ::Cartero::Command
 class Templates < ::Cartero::Command
+
+  description(
+    name: "Email Template Manager",
+    description: "This command allows you to create and mantain customizeable templates for your campaings." +
+                 "Even though it is not necessary to use this command to send templated emails, text, updates, " +
+                 "it comes in handy when you have re-usable templates such as Social Network updates, Mail Server delivery, etc.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Infrastructure",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+  
   def initialize
-    super(name: "Email Template Manager",
-      description: "This command allows you to create and mantain customizeable templates for your campaings." +
-                   "Even though it is not necessary to use this command to send templated emails, text, updates, " +
-                   "it comes in handy when you have re-usable templates such as Social Network updates, Mail Server delivery, etc.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Infrastructure",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.on("-a","--add NAME", String,
         "Add Template") do |name|
         @options.name = name

--- a/lib/cartero/payloads/beef.rb
+++ b/lib/cartero/payloads/beef.rb
@@ -3,18 +3,22 @@ module Cartero
 module Payloads
 # Documentation for Beef < ::Cartero::Payload
 class Beef < ::Cartero::Payload
+
+  description(
+    name: "Browser Exploitation Framework Plugin",
+    description: "The command will help us hook an already created cartero webserver" +
+                 ", launch beef itself, and interact with it using its API.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Payload",
+    license: "LGPL",
+    references: [
+      "https://section9labs.github.io/Cartero",
+      "http://beefproject.com"
+    ]
+  )
+  
   def initialize
-    super(name: "Browser Exploitation Framework Plugin",
-          description: "The command will help us hook an already created cartero webserver" +
-                       ", launch beef itself, and interact with it using its API.",
-          author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-          type: "Payload",
-          license: "LGPL",
-          references: [
-            "https://section9labs.github.io/Cartero",
-            "http://beefproject.com"
-          ]
-          ) do |opts|
+    super do |opts|
       opts.on("-W", "--webserver WEBSERVER_FOLDER", String,
         "Sets the sinatra WebServer full path for payload creation") do |path|
         @options.path = path

--- a/lib/cartero/payloads/msfvenom.rb
+++ b/lib/cartero/payloads/msfvenom.rb
@@ -3,15 +3,19 @@ module Cartero
 module Payloads
 # Documentation for MSFVenom < ::Cartero::Payload
 class MSFVenom < ::Cartero::Payload
-   def initialize
-    super(name: "Metasploit MSFVenon RPC Interface",
-      description: "This command is a home-made implementation of metasploit's msfvenon over metasploit's RPC protocol. " +
-                   "This allows us to generate and serve msf payloads, even from remote metasploit instances.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Payload",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+
+  description(
+    name: "Metasploit MSFVenon RPC Interface",
+    description: "This command is a home-made implementation of metasploit's msfvenon over metasploit's RPC protocol. " +
+                 "This allows us to generate and serve msf payloads, even from remote metasploit instances.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Payload",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+  
+  def initialize
+    super do |opts|
       opts.on("-W", "--webserver WEBSERVER_FOLDER", String,
         "Sets the sinatra WebServer full path for payload creation") do |path|
         @options.path = path

--- a/lib/cartero/payloads/s_m_b_redirect.rb
+++ b/lib/cartero/payloads/s_m_b_redirect.rb
@@ -3,17 +3,21 @@ module Cartero
 module Payloads
 # Documentation for SMBRedirect < ::Cartero::Payload
 class SMBRedirect < ::Cartero::Payload
-   def initialize
-    super(name: "SMBRedirect Attack Reborned",
-      description: %q{This attack is an old attack vector recently 'rediscoreved' that affects windows platforms. Attacker could force a redirec of an http link to a file:// or a \\server\file server resulting on the server leaking its credentials when trying to authenticate.},
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Payload",
-      license: "LGPL",
-      references: [
-				"http://blog.cylance.com/redirect-to-smb",
-				"https://section9labs.github.io/Cartero"
-			]
-      ) do |opts|
+
+  description(
+    name: "SMBRedirect Attack Reborned",
+    description: %q{This attack is an old attack vector recently 'rediscoreved' that affects windows platforms. Attacker could force a redirec of an http link to a file:// or a \\server\file server resulting on the server leaking its credentials when trying to authenticate.},
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Payload",
+    license: "LGPL",
+    references: [
+      "http://blog.cylance.com/redirect-to-smb",
+      "https://section9labs.github.io/Cartero"
+    ]
+  )
+
+  def initialize
+    super do |opts|
       opts.on("-W", "--webserver WEBSERVER_FOLDER", String,
         "Sets the sinatra WebServer full path for payload creation") do |path|
         @options.path = path

--- a/lib/cartero/payloads/veil_evasion.rb
+++ b/lib/cartero/payloads/veil_evasion.rb
@@ -5,14 +5,19 @@ module Payloads
 # Documentation for VeilEvasion < ::Cartero::Payload
 class VeilEvasion < ::Cartero::Payload
   include CommandLineReporter
+
+  description(
+    name: "Veil Evasion Payload RPC Builder",
+    description: "Cartero's Veil Evasion RPC client to create local and remote " +
+                 "paylods making use of the amazing and undetectable VeilEvasion paylods.",
+    author: ["Matias P. Brutti <matias [©] section9labs.com>"],
+    type: "Payload",
+    license: "LGPL",
+    references: ["https://section9labs.github.io/Cartero"]
+  )
+
   def initialize
-    super(name: "Veil Evasion Payload RPC Builder",
-      description: "Cartero's Veil Evasion RPC client to create local and remote paylods making use of the amazing and undetectable VeilEvasion paylods.",
-      author: ["Matias P. Brutti <matias [©] section9labs.com>"],
-      type: "Payload",
-      license: "LGPL",
-      references: ["https://section9labs.github.io/Cartero"]
-      ) do |opts|
+    super do |opts|
       opts.on("-W", "--webserver WEBSERVER_FOLDER", String,
         "Sets the sinatra WebServer full path for payload creation") do |path|
         @options.path = path


### PR DESCRIPTION
- Now commands have a description method to declared them which gives them easier access across application. 
- Adding support for Bash for Windows. 

Note: Support for Windows is still limited and some commands may not yet run fully. More testing and possible fixes to come. 